### PR TITLE
docs: add testing documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ docker-qgis-start: docker-up ## Start the containerized qgis
 	docker-compose exec qgis sh -c 'DISPLAY=$$1 qgis' sh "unix$$DISPLAY"
 
 .PHONY: docker-db-connect
-docker-db-connect: ## Connect to the containerized db using psql
-	docker-compose exec db su postgres -c psql
+docker-db-connect: docker-up ## Connect to the containerized db using psql
+	docker-compose exec db su postgres -c psql gazetteer
 
 .PHONY: docker-db-shell
-docker-db-shell: ## Start a shell to the containerized db
+docker-db-shell: docker-up ## Start a shell to the containerized db
 	docker-compose exec db bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,31 @@
+# Testing tools
+
+This repository comes with configuration to build and run
+2 docker containers:
+
+  - A PostgreSQL database container, with a prepared gazetteer
+    database
+
+  - A QGIS container, with a version of QGIS known to work
+    with the plugin, which is preloaded
+
+The easiest way to run both containers, already linked,
+and immediately get to use the QGIS plugin is provided
+as a Makefile target:
+
+      make docker-qgis-start
+
+Other Makefile targets do exist and are documented when
+`make` is invoked with no arguments:
+
+      make
+
+The database container runs with pre-created PostgreSQL
+cluster users that can be used to load data or otherwise
+inspect the database. You can open a psql session into
+the database with:
+
+      make docker-db-connect
+
+NOTE: any data loaded into the database will disappear
+with the container, which is volatile.


### PR DESCRIPTION
Includes documentation for connecting to the database container
for loading data or other inspection.
See #90