### PR TITLE
Enable docker-compose to run on MacOS displays.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ docker-qgis-shell: docker-up ## Start a shell in the containerized qgis
 .PHONY: docker-qgis-start
 docker-qgis-start: docker-up ## Start the containerized qgis
 	xhost +
-	docker-compose exec qgis sh -c 'DISPLAY=$$1 qgis' sh "unix$$DISPLAY"
+	docker-compose exec qgis sh -c 'DISPLAY=$$1 qgis' sh "$$DISPLAY"
 
 .PHONY: docker-qgis-test
 docker-qgis-test: docker-up ## Run python tests against QGIS isntance


### PR DESCRIPTION
Fixes: #107 

### Change Description:
Enable docker-compose to run on MacOS displays.
Removed unix socket identifier which is not supported on MacOS. Seems to still work on Ubuntu fine, maybe because unix socket is the default?

### Notes for Testing:
Tested on:
 MacOS 10.15.4 (with XQuartz 2.7.11 (xorg-server 1.18.4))
 Ubuntu 18.04

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management: 
- [ ] Linked to sub-task
- [ ] Linked to the epic
