### PR TITLE
remove extraneous imports

### DIFF
--- a/src/NZGBplugin/GazEditForms.py
+++ b/src/NZGBplugin/GazEditForms.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/Util/dms.py
+++ b/src/NZGBplugin/LINZ/Util/dms.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/Widgets/ConnectedWidget.py
+++ b/src/NZGBplugin/LINZ/Widgets/ConnectedWidget.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/Widgets/DictionaryAdaptor.py
+++ b/src/NZGBplugin/LINZ/Widgets/DictionaryAdaptor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/Widgets/SqlAlchemyAdaptor.py
+++ b/src/NZGBplugin/LINZ/Widgets/SqlAlchemyAdaptor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/Widgets/WidgetConnector.py
+++ b/src/NZGBplugin/LINZ/Widgets/WidgetConnector.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/gazetteer/Export.py
+++ b/src/NZGBplugin/LINZ/gazetteer/Export.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/gazetteer/Model.py
+++ b/src/NZGBplugin/LINZ/gazetteer/Model.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/gazetteer/gui/AdminWidget.py
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/AdminWidget.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/gazetteer/gui/Controller.py
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/Controller.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/gazetteer/gui/Editor.py
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/Editor.py
@@ -11,7 +11,6 @@
 ################################################################################
 
 
-from __future__ import absolute_import
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *

--- a/src/NZGBplugin/LINZ/gazetteer/gui/NameSearchWidget.py
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/NameSearchWidget.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/gazetteer/gui/NameWebView.py
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/NameWebView.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import with_statement
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/LINZ/gazetteer/gui/SystemCodeEditorWidget.py
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/SystemCodeEditorWidget.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/Layers.py
+++ b/src/NZGBplugin/Layers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/NewFeatureDialog.py
+++ b/src/NZGBplugin/NewFeatureDialog.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/Plugin.py
+++ b/src/NZGBplugin/Plugin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/SelectNameTool.py
+++ b/src/NZGBplugin/SelectNameTool.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ################################################################################
 #
 #  New Zealand Geographic Board gazetteer application,

--- a/src/NZGBplugin/__init__.py
+++ b/src/NZGBplugin/__init__.py
@@ -12,7 +12,6 @@
 ################################################################################
 
 
-from __future__ import absolute_import
 from .Plugin import Plugin
 
 


### PR DESCRIPTION
The qgis2to3 tool added extraneous futures import statements. As this tool is to only be supported for qgis3/python3 these are not required. 

### Change Description:
__Future__ imports removed

### Notes for Testing:
Rely on CI

