### PR TITLE
Qgis3 metadata

### DIFF
--- a/src/NZGBplugin/Plugin.py
+++ b/src/NZGBplugin/Plugin.py
@@ -15,6 +15,7 @@ from builtins import str
 from builtins import object
 import sys
 import os.path
+import configparser
 
 from PyQt5.QtGui import *
 from PyQt5.QtCore import *
@@ -28,14 +29,12 @@ from .SelectNameTool import SelectNameTool
 
 class Plugin(object):
 
-    Name = "GazetteerEditor"
-    LongName = "GazetteerEditor plugin for QGIS"
-    Version = "1.8.2"
-    QgisMinimumVersion = "2.4"
-    Author = "ccrook@linz.govt.nz <Chris Crook>"
-    PluginUrl = "http://<server>/QgisPluginRepository/GazetteerEditor.zip"
-    Description = "Gazetteer database editor"
+    file_path = os.path.join(os.path.dirname(__file__), "metadata.txt")
+    parser = configparser.ConfigParser()
+    parser.read(file_path)
 
+    Version = parser["general"]["Version"]
+    Name = parser["general"]["Name"]
     _menuName = "Gazetteer editor"
 
     def __init__(self, iface):

--- a/src/NZGBplugin/Plugin.py
+++ b/src/NZGBplugin/Plugin.py
@@ -223,20 +223,20 @@ class Plugin(object):
             version = self._controller.database().scalar(
                 "select value from system_code where code_group='APSD' and code='VRSN'"
             )
-            #             # temp comments out see #103
-            #             if version != self.Version:
-            #                 result = QMessageBox.question(
-            #                     self._iface.mainWindow(),
-            #                     "Application version error",
-            #                     "You are using version "
-            #                     + self.Version
-            #                     + " of the gazetteer plugin,\n"
-            #                     "but the current version is " + version + "\n\n"
-            #                     "Do you want to continue with this version?",
-            #                     QMessageBox.Yes | QMessageBox.No,
-            #                 )
-            #                 if result != QMessageBox.Yes:
-            #                     return
+
+            if version != self.Version:
+                result = QMessageBox.question(
+                    self._iface.mainWindow(),
+                    "Application version error",
+                    "You are using version "
+                    + self.Version
+                    + " of the gazetteer plugin,\n"
+                    "but the current version is " + version + "\n\n"
+                    "Do you want to continue with this version?",
+                    QMessageBox.Yes | QMessageBox.No,
+                )
+                if result != QMessageBox.Yes:
+                    return
 
             from .LINZ.gazetteer.gui.Editor import Editor
             from . import Layers

--- a/src/NZGBplugin/metadata.txt
+++ b/src/NZGBplugin/metadata.txt
@@ -9,5 +9,5 @@ about=QGIS plugin that allows the Geographic board to manage official
 author=Chris Crook
 qgisMinimumVersion=3.10
 description=For maintaining the NZGB gazetteer.
-version=version 1.8.2
+version=1.8.2
 experimental=False

--- a/src/sql/gazetteer_app_sysdata.sql
+++ b/src/sql/gazetteer_app_sysdata.sql
@@ -19,7 +19,7 @@ DELETE FROM system_code WHERE code_group='CODE' AND code='APSD';
 
 INSERT INTO system_code (code_group, code, category, value, description ) VALUES
 ('CODE','APSD','USER','Application data',NULL),
-('APSD','VRSN',NULL,'1.4','Current application version'),
+('APSD','VRSN',NULL,'1.8.2','Current application version'),
 ('APSD','NAOR',NULL,'NPUB HORM FLRF NNOT CPAL SCID SCRB SCHT UFGT UFAC UFRG UFAD UFGP NTDC NTAR DOCC DOCR MGRS','Order in which to display name annotations'),
 ('APSD','FAOR',NULL,'NPUB LDIS ISLD FNOT','Order in which to display feature annotations');
 


### PR DESCRIPTION
Fixes: #
* #101
* #103

addresses 
* #82

### Change Description:
* moves duplicated hard coded metadata to metadata.txt
* re-enables APP metadata vs DB metadata checking
* brings DB metadata DB verison to 1.8.2 to match prd

...

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [x] Linked to sub-task
- [ ] Linked to the epic
