### PR TITLE
Fix admin workflow import errors

### DIFF
--- a/src/NZGBplugin/LINZ/Widgets/ConnectedWidget.py
+++ b/src/NZGBplugin/LINZ/Widgets/ConnectedWidget.py
@@ -11,6 +11,7 @@
 
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 
 from .ValidatorList import ValidatorList
 from .WidgetConnector import WidgetConnector

--- a/src/NZGBplugin/LINZ/gazetteer/gui/AdminWidget.py
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/AdminWidget.py
@@ -22,6 +22,7 @@ if __name__ == "__main__":
 
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 
 from LINZ.Widgets import QtUtils
 from LINZ.Widgets.SqlAlchemyAdaptor import SqlAlchemyAdaptor

--- a/src/NZGBplugin/LINZ/gazetteer/gui/SystemCodeEditorWidget.py
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/SystemCodeEditorWidget.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
 
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
+from PyQt5.QtWidgets import QWidget
 
 from .Ui_SystemCodeEditorWidget import Ui_SystemCodeEditorWidget
 

--- a/src/NZGBplugin/LINZ/gazetteer/gui/Ui_AdminWidget.py
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/Ui_AdminWidget.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'LINZ/gazetteer/gui/Ui_AdminWidget.ui'
+# Form implementation generated from reading ui file 'Ui_AdminWidget.ui'
 #
-# Created by: PyQt5 UI code generator 5.9.2
+# Created by: PyQt5 UI code generator 5.10.1
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -180,5 +180,5 @@ class Ui_AdminWidget(object):
         )
 
 
+from .SystemCodeEditorWidget import SystemCodeEditorWidget
 from LINZ.Widgets.ListModelConnector import ListModelTableView
-from SystemCodeEditorWidget import SystemCodeEditorWidget

--- a/src/NZGBplugin/LINZ/gazetteer/gui/Ui_AdminWidget.ui
+++ b/src/NZGBplugin/LINZ/gazetteer/gui/Ui_AdminWidget.ui
@@ -249,7 +249,7 @@ When you run the update the web database may be unavailable for about 5 minutes 
   <customwidget>
    <class>SystemCodeEditorWidget</class>
    <extends>QWidget</extends>
-   <header>SystemCodeEditorWidget</header>
+   <header>.SystemCodeEditorWidget</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/NZGBplugin/NewFeatureDialog.py
+++ b/src/NZGBplugin/NewFeatureDialog.py
@@ -14,6 +14,8 @@ from builtins import str
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from qgis.core import *
+from PyQt5.QtWidgets import *
+
 
 from .LINZ.gazetteer.gui.Controller import Controller
 from .LINZ.gazetteer.gui import FormUtils


### PR DESCRIPTION
Fixes: #
#137 - Admin gui failed to open due to import error

### Change Description:
admin gui imports upgraded for python3 + pyqt5

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [ ] Linked to sub-task
- [ ] Linked to the epic
