### PR TITLE
add user to dba

### DIFF
--- a/src/sql/Dockerfile
+++ b/src/sql/Dockerfile
@@ -57,5 +57,13 @@ ENTRYPOINT su - postgres -c "/usr/lib/postgresql/8.4/bin/postgres \
   "
 
 RUN pg_ctlcluster 8.4 main start && \
+    echo "create user gazowner IN ROLE gaz_owner password 'gazowner'" | \
+    su postgres -c psql && \
+    echo "create user gazexport IN ROLE gazetteer_export password 'gazexport'" | \
+    su postgres -c psql && \
+    echo "create user gazuser IN ROLE gazetteer_user password 'gazuser'" | \
+    su postgres -c psql && \
     echo "create user gazadmin IN ROLE gazetteer_admin password 'gazadmin'" | \
+    su postgres -c psql && \
+    echo "create user gazdba IN ROLE gazetteer_admin, gazetteer_dba password 'gazdba'" | \
     su postgres -c psql


### PR DESCRIPTION
Fixes: #
#136
as per the below. The gazadmin user must be a member of gazetteer_dba to be considered an application admin and use admin functionality 

The below function is used to determine if a user of the QGS plugin is a application admin

https://github.com/linz/gazetteer/blob/ec7caa01bf19aa49521c1c93acf3355954819d8c/src/sql/gazetteer_add_user.sql#L105-L112

### Change Description:
see above
...

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [ ] Linked to sub-task
- [ ] Linked to the epic
