### PR TITLE
refactor: do not set PGUSER/PGPASSWORD at startup

### DIFF
--- a/.docker/qgis/scripts/startup.py
+++ b/.docker/qgis/scripts/startup.py
@@ -21,8 +21,6 @@ os.environ["PGHOST"] = "db"
 os.environ["PGPORT"] = "5432"
 os.environ["PGDATABASE"] = "gazetteer"
 os.environ["PGSCHEMA"] = "gazetteer"
-os.environ["PGUSER"] = "gazadmin"
-os.environ["PGPASSWORD"] = "gazadmin"
 
 utils.showException = _showException
 utils.open_stack_dialog = _open_stack_dialog

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ docker-qgis-start: docker-up ## Start the containerized qgis
 	xhost +
 	docker-compose exec qgis sh -c 'DISPLAY=$$1 qgis' sh "$$DISPLAY"
 
+.PHONY: docker-qgis-start-dba
+docker-qgis-start-dba: docker-up ## Start the containerized qgis
+	xhost +
+	docker-compose exec qgis sh -c 'DISPLAY=$$1 PGUSER=gazdba PGPASSWORD=gazdba qgis' sh "$$DISPLAY"
+
 .PHONY: docker-qgis-test
 docker-qgis-test: docker-up ## Run python tests against QGIS isntance
 	docker-compose exec -T qgis sh -c "/usr/bin/xvfb-run -- qgis_testrunner.sh tests_directory.run_tests.run_test_modules"


### PR DESCRIPTION
Rather rely on calling env.
This allows docker-compose.yml to drive those variables