### PR TITLE
qgis requires rules to be returning on insert

### DIFF
--- a/src/sql/gazetteer_geometry_views.sql
+++ b/src/sql/gazetteer_geometry_views.sql
@@ -23,21 +23,25 @@ SELECT
 from
     gazetteer.feature;
 
-CREATE RULE feature_ref_point_ins AS ON INSERT TO feature_ref_point
+CREATE OR REPLACE RULE feature_ref_point_ins AS ON INSERT TO feature_ref_point
 DO INSTEAD
    (
    INSERT INTO feature (feat_type, status, description, ref_point )
    VALUES (NEW.feat_type, 'CURR', '', NEW.ref_point );
    INSERT INTO name (feat_id, name, status )
    VALUES (lastval(), NEW.name, 'UNEW' )
-   );
+   RETURNING
+     feat_id,
+     gaz_preferredName(feat_id) as name,
+     (SELECT f.feat_type FROM feature f WHERE f.feat_id = feat_id),
+     (SELECT f.ref_point FROM feature f WHERE f.feat_id  = feat_id));
 
-CREATE RULE feature_ref_point_upd AS ON UPDATE TO feature_ref_point
+CREATE OR REPLACE RULE feature_ref_point_upd AS ON UPDATE TO feature_ref_point
 DO INSTEAD
-   UPDATE gazetteer.feature
-   SET
-     ref_point = NEW.ref_point
-   WHERE feat_id =  NEW.feat_id;
+    UPDATE gazetteer.feature
+    SET
+        ref_point = NEW.ref_point
+    WHERE feat_id = NEW.feat_id;
 
 -- -------------------------------------
 -- Views of geometry table
@@ -78,125 +82,138 @@ FROM
 WHERE
     geom_type='P';
 
-CREATE RULE feature_point_ins AS ON INSERT TO feature_point
+CREATE OR REPLACE RULE feature_point_ins AS ON INSERT TO feature_point
 DO INSTEAD
-   INSERT INTO gazetteer.feature_geometry(
+    INSERT INTO gazetteer.feature_geometry(
         feat_id,
         geom_type,
         shape
         )
-   VALUES (
+    VALUES (
         NEW.feat_id,
         CASE
-        WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
-        WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
-        WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
+            WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
+            WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
+            WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
         END,
         NEW.shape
-        );
+        )
+    RETURNING
+        (SELECT g.geom_id FROM feature_geometry g WHERE g.feat_id = feat_id),
+        feat_id,
+        gaz_preferredName(feat_id) as name,
+        shape;
 
-CREATE RULE feature_point_upd AS ON UPDATE TO feature_point
+CREATE OR REPLACE RULE feature_point_upd AS ON UPDATE TO feature_point
 DO INSTEAD
-   UPDATE gazetteer.feature_geometry
-   SET
-     feat_id = NEW.feat_id,
-     geom_type =
-        CASE
-        WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
-        WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
-        WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
-        END,
-     shape =  NEW.shape
-   WHERE geom_id =  NEW.geom_id;
+    UPDATE gazetteer.feature_geometry
+    SET
+        feat_id = NEW.feat_id,
+        geom_type =
+            CASE
+                WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
+                WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
+                WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
+            END,
+        shape = NEW.shape
+    WHERE geom_id = NEW.geom_id;
 
-CREATE RULE feature_point_del AS ON DELETE TO feature_point
+CREATE OR REPLACE RULE feature_point_del AS ON DELETE TO feature_point
 DO INSTEAD
-   DELETE FROM gazetteer.feature_geometry
-   WHERE geom_id =  OLD.geom_id;
+    DELETE FROM gazetteer.feature_geometry
+    WHERE geom_id = OLD.geom_id;
 
-CREATE RULE feature_line_ins AS ON INSERT TO feature_line
+
+CREATE OR REPLACE RULE feature_line_ins AS ON INSERT TO feature_line
 DO INSTEAD
-   INSERT INTO gazetteer.feature_geometry(
+    INSERT INTO gazetteer.feature_geometry(
         feat_id,
         geom_type,
         shape
         )
-   VALUES (
+    VALUES (
         NEW.feat_id,
         CASE
-        WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
-        WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
-        WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
+            WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
+            WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
+            WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
         END,
         NEW.shape
-        );
+        )
+    RETURNING
+        (SELECT g.geom_id FROM feature_geometry g WHERE g.feat_id = feat_id),
+        feat_id,
+        gaz_preferredName(feat_id) as name,
+        shape;
 
-CREATE RULE feature_line_upd AS ON UPDATE TO feature_line
+CREATE OR REPLACE RULE feature_line_upd AS ON UPDATE TO feature_line
 DO INSTEAD
-   UPDATE gazetteer.feature_geometry
-   SET
-     feat_id = NEW.feat_id,
-     geom_type =
-        CASE
-        WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
-        WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
-        WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
-        END,
-     shape =  NEW.shape
-   WHERE geom_id =  NEW.geom_id;
+    UPDATE gazetteer.feature_geometry
+    SET
+        feat_id = NEW.feat_id,
+        geom_type =
+            CASE
+                WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
+                WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
+                WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
+            END,
+        shape = NEW.shape
+    WHERE geom_id = NEW.geom_id;
 
-CREATE RULE feature_line_del AS ON DELETE TO feature_line
+CREATE OR REPLACE RULE feature_line_del AS ON DELETE TO feature_line
 DO INSTEAD
-   DELETE FROM gazetteer.feature_geometry
-   WHERE geom_id =  OLD.geom_id;
+    DELETE FROM gazetteer.feature_geometry
+    WHERE geom_id = OLD.geom_id;
 
 
-CREATE RULE feature_polygon_ins AS ON INSERT TO feature_polygon
+CREATE OR REPLACE RULE feature_polygon_ins AS ON INSERT TO feature_polygon
 DO INSTEAD
-   INSERT INTO gazetteer.feature_geometry(
+    INSERT INTO gazetteer.feature_geometry(
         feat_id,
         geom_type,
         shape
         )
-   VALUES (
+    VALUES (
         NEW.feat_id,
         CASE
-        WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
-        WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
-        WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
+            WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
+            WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
+            WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
         END,
         NEW.shape
-        );
+        )
+    RETURNING
+        (SELECT g.geom_id FROM feature_geometry g WHERE g.feat_id = feat_id),
+        feat_id,
+        gaz_preferredName(feat_id) as name,
+        shape;
 
-CREATE RULE feature_polygon_upd AS ON UPDATE TO feature_polygon
+CREATE OR REPLACE RULE feature_polygon_upd AS ON UPDATE TO feature_polygon
 DO INSTEAD
-   UPDATE gazetteer.feature_geometry
-   SET
-     feat_id = NEW.feat_id,
-     geom_type =
+    UPDATE gazetteer.feature_geometry
+    SET
+        feat_id = NEW.feat_id,
+        geom_type =
         CASE
-        WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
-        WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
-        WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
+            WHEN GeometryType( NEW.SHAPE) like '%POINT' THEN 'X'
+            WHEN GeometryType( NEW.SHAPE) like '%LINESTRING' THEN 'L'
+            WHEN GeometryType( NEW.SHAPE) like '%POLYGON' THEN 'P'
         END,
-     shape =  NEW.shape
-   WHERE geom_id =  NEW.geom_id;
+        shape = NEW.shape
+    WHERE geom_id = NEW.geom_id;
 
-CREATE RULE feature_polygon_del AS ON DELETE TO feature_polygon
+CREATE OR REPLACE RULE feature_polygon_del AS ON DELETE TO feature_polygon
 DO INSTEAD
-   DELETE FROM gazetteer.feature_geometry
-   WHERE geom_id =  OLD.geom_id;
+    DELETE FROM gazetteer.feature_geometry
+    WHERE geom_id = OLD.geom_id;
 
 DELETE FROM geometry_columns
     WHERE f_table_schema='gazetteer' AND
-          f_table_name IN ('feature_ref_point', 'feature_point', 'feature_line', 'feature_polygon');
+        f_table_name IN ('feature_ref_point', 'feature_point', 'feature_line', 'feature_polygon');
 
 INSERT INTO geometry_columns(f_table_catalog, f_table_schema, f_table_name, f_geometry_column, coord_dimension, srid, "type")
 VALUES
-  ('', 'gazetteer', 'feature_ref_point', 'ref_point', 2, 4167, 'POINT'),
-  ('', 'gazetteer', 'feature_point', 'shape', 2, 4167, 'POINT'),
-  ('', 'gazetteer', 'feature_line', 'shape', 2, 4167, 'LINESTRING'),
-  ('', 'gazetteer', 'feature_polygon', 'shape', 2, 4167, 'POLYGON');
-
-
-
+    ('', 'gazetteer', 'feature_ref_point', 'ref_point', 2, 4167, 'POINT'),
+    ('', 'gazetteer', 'feature_point', 'shape', 2, 4167, 'POINT'),
+    ('', 'gazetteer', 'feature_line', 'shape', 2, 4167, 'LINESTRING'),
+    ('', 'gazetteer', 'feature_polygon', 'shape', 2, 4167, 'POLYGON');


### PR DESCRIPTION
Fixes: #
* #157

### Change Description:
A change to QGIS 2.16 source code required inserts on views (underlying tables) to be returning so that the postgres data-provider can update the layer with the returned row. 

### Notes for Testing:
Tests are being developed as part of this sprint. 

Manual testing shows this has been resolved by these changes. 

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [ ] Linked to sub-task
- [ ] Linked to the epic
