### PR TITLE
remove root layers

### DIFF
--- a/src/NZGBplugin/Layers.py
+++ b/src/NZGBplugin/Layers.py
@@ -309,6 +309,8 @@ class Layers(QObject):
         # add layer to group
         for lyr in self.layers(group):
             group_ref.addLayer(lyr)
+            # Remove the layer from
+            root.removeLayer(lyr)
 
     # Return layer defs in defined order
     def layerDefs(self):


### PR DESCRIPTION
Fixes: #
* #159

### Change Description:
The QGIS2 legend API had a moveLayer method available which moved layers to nodes/groups. The layerTreeView that replaces QGIS2's legend does not have this available but rather add and remove.

Initial porting employed the move but not the remove method. This resulted in layers both in the trees root and children/groups

This PR removes layers from the root and moving groups as to provide the same user experience as the app currently does in QGIS2 with groups. 

...

### Notes for Testing:
Tests in dev in test_edit_geom branch. This is a blockage to this main task
...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [ ] Linked to sub-task
- [ ] Linked to the epic
