### PR TITLE
fix to rules returning multiple rows

### DIFF
--- a/src/sql/gazetteer_geometry_views.sql
+++ b/src/sql/gazetteer_geometry_views.sql
@@ -31,24 +31,15 @@ DO INSTEAD
     INSERT INTO name (feat_id, name, status )
     VALUES (lastval(), NEW.name, 'UNEW' )
     RETURNING
-       	(SELECT feat_id
-		FROM gazetteer.feature
-		ORDER BY feat_id DESC
-		LIMIT 1),
-
-  		(SELECT gazetteer.gaz_preferredname(feat_id)
-		FROM gazetteer.feature_geometry
-		ORDER BY feat_id DESC
-		LIMIT 1),
-
+        feat_id,
+        gaz_preferredname(feat_id),
        	(SELECT feat_type
 		FROM gazetteer.feature
 		ORDER BY feat_id DESC
 		LIMIT 1),
-
-  		(SELECT ref_point
-		FROM gazetteer.feature
-		ORDER BY feat_id DESC
+  		(SELECT shape
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
 		LIMIT 1)
 	);
 
@@ -119,21 +110,9 @@ DO INSTEAD
 		FROM gazetteer.feature_geometry
 		ORDER BY geom_id DESC
 		LIMIT 1),
-
-  		(SELECT feat_id
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
-		LIMIT 1),
-
-  		(SELECT gazetteer.gaz_preferredname(feat_id)
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
-		LIMIT 1),
-
-  		(SELECT shape
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
-		LIMIT 1);
+        feat_id,
+        gaz_preferredname(feat_id),
+        shape;
 
 CREATE OR REPLACE RULE feature_point_upd AS ON UPDATE TO feature_point
 DO INSTEAD
@@ -172,25 +151,13 @@ DO INSTEAD
         NEW.shape
         )
     RETURNING
-        (SELECT geom_id
+  		(SELECT geom_id
 		FROM gazetteer.feature_geometry
 		ORDER BY geom_id DESC
 		LIMIT 1),
-
-  		(SELECT feat_id
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
-		LIMIT 1),
-
-  		(SELECT gazetteer.gaz_preferredname(feat_id)
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
-		LIMIT 1),
-
-  		(SELECT shape
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
-		LIMIT 1);
+        feat_id,
+        gaz_preferredname(feat_id),
+        shape;
 
 CREATE OR REPLACE RULE feature_line_upd AS ON UPDATE TO feature_line
 DO INSTEAD
@@ -229,25 +196,13 @@ DO INSTEAD
         NEW.shape
         )
     RETURNING
-        (SELECT geom_id
+  		(SELECT geom_id
 		FROM gazetteer.feature_geometry
 		ORDER BY geom_id DESC
 		LIMIT 1),
-
-  		(SELECT feat_id
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
-		LIMIT 1),
-
-  		(SELECT gazetteer.gaz_preferredname(feat_id)
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
-		LIMIT 1),
-
-  		(SELECT shape
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
-		LIMIT 1);
+        feat_id,
+        gaz_preferredname(feat_id),
+        shape;
 
 CREATE OR REPLACE RULE feature_polygon_upd AS ON UPDATE TO feature_polygon
 DO INSTEAD

--- a/src/sql/gazetteer_geometry_views.sql
+++ b/src/sql/gazetteer_geometry_views.sql
@@ -37,9 +37,9 @@ DO INSTEAD
 		FROM gazetteer.feature
 		ORDER BY feat_id DESC
 		LIMIT 1),
-  		(SELECT shape
-		FROM gazetteer.feature_geometry
-		ORDER BY geom_id DESC
+  		(SELECT ref_point
+		FROM gazetteer.feature
+		ORDER BY feat_id DESC
 		LIMIT 1)
 	);
 

--- a/src/sql/gazetteer_geometry_views.sql
+++ b/src/sql/gazetteer_geometry_views.sql
@@ -25,16 +25,32 @@ from
 
 CREATE OR REPLACE RULE feature_ref_point_ins AS ON INSERT TO feature_ref_point
 DO INSTEAD
-   (
-   INSERT INTO feature (feat_type, status, description, ref_point )
-   VALUES (NEW.feat_type, 'CURR', '', NEW.ref_point );
-   INSERT INTO name (feat_id, name, status )
-   VALUES (lastval(), NEW.name, 'UNEW' )
-   RETURNING
-     feat_id,
-     gaz_preferredName(feat_id) as name,
-     (SELECT f.feat_type FROM feature f WHERE f.feat_id = feat_id),
-     (SELECT f.ref_point FROM feature f WHERE f.feat_id  = feat_id));
+    (
+    INSERT INTO feature (feat_type, status, description, ref_point )
+    VALUES (NEW.feat_type, 'CURR', '', NEW.ref_point );
+    INSERT INTO name (feat_id, name, status )
+    VALUES (lastval(), NEW.name, 'UNEW' )
+    RETURNING
+       	(SELECT feat_id
+		FROM gazetteer.feature
+		ORDER BY feat_id DESC
+		LIMIT 1),
+
+  		(SELECT gazetteer.gaz_preferredname(feat_id)
+		FROM gazetteer.feature_geometry
+		ORDER BY feat_id DESC
+		LIMIT 1),
+
+       	(SELECT feat_type
+		FROM gazetteer.feature
+		ORDER BY feat_id DESC
+		LIMIT 1),
+
+  		(SELECT ref_point
+		FROM gazetteer.feature
+		ORDER BY feat_id DESC
+		LIMIT 1)
+	);
 
 CREATE OR REPLACE RULE feature_ref_point_upd AS ON UPDATE TO feature_ref_point
 DO INSTEAD
@@ -99,10 +115,25 @@ DO INSTEAD
         NEW.shape
         )
     RETURNING
-        (SELECT g.geom_id FROM feature_geometry g WHERE g.feat_id = feat_id),
-        feat_id,
-        gaz_preferredName(feat_id) as name,
-        shape;
+  		(SELECT geom_id
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1),
+
+  		(SELECT feat_id
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1),
+
+  		(SELECT gazetteer.gaz_preferredname(feat_id)
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1),
+
+  		(SELECT shape
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1);
 
 CREATE OR REPLACE RULE feature_point_upd AS ON UPDATE TO feature_point
 DO INSTEAD
@@ -141,10 +172,25 @@ DO INSTEAD
         NEW.shape
         )
     RETURNING
-        (SELECT g.geom_id FROM feature_geometry g WHERE g.feat_id = feat_id),
-        feat_id,
-        gaz_preferredName(feat_id) as name,
-        shape;
+        (SELECT geom_id
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1),
+
+  		(SELECT feat_id
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1),
+
+  		(SELECT gazetteer.gaz_preferredname(feat_id)
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1),
+
+  		(SELECT shape
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1);
 
 CREATE OR REPLACE RULE feature_line_upd AS ON UPDATE TO feature_line
 DO INSTEAD
@@ -183,10 +229,25 @@ DO INSTEAD
         NEW.shape
         )
     RETURNING
-        (SELECT g.geom_id FROM feature_geometry g WHERE g.feat_id = feat_id),
-        feat_id,
-        gaz_preferredName(feat_id) as name,
-        shape;
+        (SELECT geom_id
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1),
+
+  		(SELECT feat_id
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1),
+
+  		(SELECT gazetteer.gaz_preferredname(feat_id)
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1),
+
+  		(SELECT shape
+		FROM gazetteer.feature_geometry
+		ORDER BY geom_id DESC
+		LIMIT 1);
 
 CREATE OR REPLACE RULE feature_polygon_upd AS ON UPDATE TO feature_polygon
 DO INSTEAD


### PR DESCRIPTION
Fixes: #

* #165 
### Change Description:
# Advancing testing showed that the returning rules create to provide view integration resulted in the #165 error. 

These changes ensure that only one row is returned when insert against the view are called.  


...

### Notes for Testing:
This has been manually tested to prove it resolves the #165 issues.
Automated tests first detected this issue. These test (which are still under development) pass with this change. 

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [ ] Linked to sub-task
- [ ] Linked to the epic
