### PR TITLE
allow docker qgis users to run python macro

### DIFF
--- a/.docker/qgis/scripts/startup.py
+++ b/.docker/qgis/scripts/startup.py
@@ -1,4 +1,6 @@
 from qgis import utils
+from PyQt5.QtCore import QSettings
+
 import traceback
 import os
 
@@ -27,3 +29,6 @@ os.environ["PGPASSWORD"] = "gazadmin"
 utils.showException = _showException
 utils.open_stack_dialog = _open_stack_dialog
 
+# Allow the use of python macros
+s = QSettings()
+s.setValue("qgis/enableMacros", "Always")


### PR DESCRIPTION
Fixes: #
resolves #185 - This saw QGIS throw a blocking pop-up asking if the user wanted to use python macros

### Change Description:


### Notes for Testing:
The expectation is this should get CI passing again


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [ ] Linked to sub-task
- [ ] Linked to the epic
