### PR TITLE
correctly order layers

### DIFF
--- a/src/NZGBplugin/Layers.py
+++ b/src/NZGBplugin/Layers.py
@@ -31,24 +31,14 @@ class Layers(QObject):
 
     _layerDefs = [
         {
-            "id": "fpoly",
+            "id": "frefpt",
             "group": "feature",
-            "table": "feature_polygon",
-            "geom": "shape",
-            "key": "geom_id",
-            "form": "featgeom.ui",
-            "init": "openFeatGeomForm",
-            "wkbtype": QgsWkbTypes.MultiPolygon,
-        },
-        {
-            "id": "fline",
-            "group": "feature",
-            "table": "feature_line",
-            "geom": "shape",
-            "key": "geom_id",
-            "form": "featgeom.ui",
-            "init": "openFeatGeomForm",
-            "wkbtype": QgsWkbTypes.MultiLineString,
+            "table": "feature_ref_point",
+            "geom": "ref_point",
+            "key": "feat_id",
+            "form": "featrefpt.ui",
+            "init": "openFeatRefPointForm",
+            "wkbtype": QgsWkbTypes.Point,
         },
         {
             "id": "fpoint",
@@ -61,30 +51,33 @@ class Layers(QObject):
             "wkbtype": QgsWkbTypes.MultiPoint,
         },
         {
-            "id": "frefpt",
+            "id": "fline",
             "group": "feature",
-            "table": "feature_ref_point",
-            "geom": "ref_point",
-            "key": "feat_id",
-            "form": "featrefpt.ui",
-            "init": "openFeatRefPointForm",
-            "wkbtype": QgsWkbTypes.Point,
-        },
-        {
-            "id": "spoly",
-            "group": "search",
-            "table": "feature_polygon",
-            "geom": "shape",
-            "key": "geom_id",
-            "wkbtype": QgsWkbTypes.MultiPolygon,
-        },
-        {
-            "id": "sline",
-            "group": "search",
             "table": "feature_line",
             "geom": "shape",
             "key": "geom_id",
+            "form": "featgeom.ui",
+            "init": "openFeatGeomForm",
             "wkbtype": QgsWkbTypes.MultiLineString,
+        },
+        {
+            "id": "fpoly",
+            "group": "feature",
+            "table": "feature_polygon",
+            "geom": "shape",
+            "key": "geom_id",
+            "form": "featgeom.ui",
+            "init": "openFeatGeomForm",
+            "wkbtype": QgsWkbTypes.MultiPolygon,
+        },
+        {
+            "id": "srefpt",
+            "group": "search",
+            "table": "feature_ref_point",
+            "geom": "ref_point",
+            "key": "feat_id",
+            "init": "openFeatRefPointForm",
+            "wkbtype": QgsWkbTypes.Point,
         },
         {
             "id": "spoint",
@@ -95,13 +88,20 @@ class Layers(QObject):
             "wkbtype": QgsWkbTypes.MultiPoint,
         },
         {
-            "id": "srefpt",
+            "id": "sline",
             "group": "search",
-            "table": "feature_ref_point",
-            "geom": "ref_point",
-            "key": "feat_id",
-            "init": "openFeatRefPointForm",
-            "wkbtype": QgsWkbTypes.Point,
+            "table": "feature_line",
+            "geom": "shape",
+            "key": "geom_id",
+            "wkbtype": QgsWkbTypes.MultiLineString,
+        },
+        {
+            "id": "spoly",
+            "group": "search",
+            "table": "feature_polygon",
+            "geom": "shape",
+            "key": "geom_id",
+            "wkbtype": QgsWkbTypes.MultiPolygon,
         },
     ]
 
@@ -296,8 +296,8 @@ class Layers(QObject):
         # If updated, then add layers to group...
 
         if updated:
-            self.moveLayersIntoGroup("search", "Gazetteer search results")
             self.moveLayersIntoGroup("feature", "Gazetteer feature")
+            self.moveLayersIntoGroup("search", "Gazetteer search results")
 
         # Find the MultiCurveM
         self._layersOk = ok

--- a/src/NZGBplugin/tests/test_ui_elements.py
+++ b/src/NZGBplugin/tests/test_ui_elements.py
@@ -79,6 +79,29 @@ class TestUi(unittest.TestCase):
         layers = [layer.name() for layer in QgsProject.instance().mapLayers().values()]
         assert layers == expected_loaded_layers
 
+    def test_AA_layer_order(self):
+        """
+        Layers must be loaded in the below particular order
+        """
+
+        root = QgsProject.instance().layerTreeRoot()
+        layer_order = root.layerOrder()
+
+        # Test layer order by layer name
+        self.assertSequenceEqual(
+            [layer.name() for layer in layer_order],
+            [
+                "Gazetteer feature refpt",
+                "Gazetteer feature point",
+                "Gazetteer feature line",
+                "Gazetteer feature poly",
+                "Gazetteer search refpt",
+                "Gazetteer search point",
+                "Gazetteer search line",
+                "Gazetteer search poly",
+            ],
+        )
+
     def test_B_tools_enabled_on_start(self):
         """
         Test starting the plugin enables the correct tools


### PR DESCRIPTION
Fixes: #
# 204 Geometry Layers load on default in reverse order

### Change Description:
QGIS3 has changed the order in which layers are added to the QgsLayerTree and MapCanvas. This has resulted in the reversal of ordering. 

This fix follows the same principle the plugin has always used to order layers - A list (lists maintain order). To reverse  the QQgsLayerTree and MapCanvas order to reflect what QGIS2 provided the user the layer definition list has been reversed. There are other ways to force order which require much more engineering. These other methods have not been implemented for this fix as this fix sticks with the status quo design and works. 

Tests provided to ensure regression is not introduced that affects layer ordering in the future  

### Notes for Testing:
Automated tests will ensure the order is as expected. 
...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [ ] Linked to sub-task
- [ ] Linked to the epic
