### PR TITLE
enable new geom tool for relevent layers only

### DIFF
--- a/src/NZGBplugin/Layers.py
+++ b/src/NZGBplugin/Layers.py
@@ -352,8 +352,25 @@ class Layers(QObject):
         self.selectEditLayer(addNew)
         self.startEdit.emit()
 
+    def isEditableByAPP(self, currentLayer):
+        if not currentLayer:
+            return False
+
+        if currentLayer.name() not in [
+            "Gazetteer feature refpt",
+            "Gazetteer feature point",
+            "Gazetteer feature line",
+            "Gazetteer feature poly",
+        ]:
+            return False
+        return True
+
     def selectEditLayer(self, addNew=False):
-        currentLayer = self._iface.mapCanvas().currentLayer()
+        currentLayer = self._iface.activeLayer()
+        editable = self.isEditableByAPP(currentLayer)
+        if not editable:
+            return None
+
         nfeat = -1
         editlayer = None
         for glayer in self.layerDefs():


### PR DESCRIPTION
Fixes: #
#217

### Change Description:
only enable new geom tool for gaz feat layers
...

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [ ] Linked to sub-task
- [ ] Linked to the epic
