### PR TITLE
Add other versions of postgres to CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
         matrix:
-            pg: [ '11', '12', '13' ]
-            pgis: ['2.5', '3' ]
+            pg: [ 11, 12, 13 ]
+            pgis: [ 2.5, 3 ]
             exclude:
                 # exclude pgis 2.5 on pg 13
-                - pg: '13'
-                    pgis: '2.5'
+                - pg: 13
+                    pgis: 2.5
     env:
       # Make apt non-interactive by default, and not showing progress
       APT: "apt-get -o Dpkg::Progress=0 -o Dpkg::Use-Pty=0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,12 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
         matrix:
-            pg: [ '12' ]
-            pgis: [ '3' ]
+            pg: [ '11', '12', '13' ]
+            pgis: ['2.5', '3' ]
+            exclude:
+                # exclude pgis 2.5 on pg 13
+                - pg: '13
+                  pgis: '2.5'
     env:
       # Make apt non-interactive by default, and not showing progress
       APT: "apt-get -o Dpkg::Progress=0 -o Dpkg::Use-Pty=0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,9 @@ jobs:
     strategy:
         matrix:
             pg: [ 11, 12, 13 ]
-            pgis: [ 2.5, 3, 3.1 ]
+            pgis: [ 2.5, 3 ]
             exclude:
-                # exclude pgis 2.5 on pg 13
-                - pg: 11
-                  pgis: 3.1
+                # exclude incompatible versions of PostGIS
                 - pg: 13
                   pgis: 2.5
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
         matrix:
             pg: [ 11, 12, 13 ]
-            pgis: [ 2.5, 3 ]
+            pgis: [ 2.5, 3, 3.1 ]
             exclude:
                 # exclude pgis 2.5 on pg 13
                 - pg: 13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
             pgis: ['2.5', '3' ]
             exclude:
                 # exclude pgis 2.5 on pg 13
-                - pg: '13
-                  pgis: '2.5'
+                - pg: '13'
+                    pgis: '2.5'
     env:
       # Make apt non-interactive by default, and not showing progress
       APT: "apt-get -o Dpkg::Progress=0 -o Dpkg::Use-Pty=0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             exclude:
                 # exclude pgis 2.5 on pg 13
                 - pg: 13
-                    pgis: 2.5
+                  pgis: 2.5
     env:
       # Make apt non-interactive by default, and not showing progress
       APT: "apt-get -o Dpkg::Progress=0 -o Dpkg::Use-Pty=0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
             pgis: [ 2.5, 3, 3.1 ]
             exclude:
                 # exclude pgis 2.5 on pg 13
+                - pg: 11
+                  pgis: 3.1
                 - pg: 13
                   pgis: 2.5
     env:


### PR DESCRIPTION
Fixes: #245 
_Add new line for each issue that was fixed_

### Change Description:
Added PostgresSQL 11 and 13 to CI matrix
Added PostGIS 2.5 to CI matrix

### Notes for Testing:
CI tests passing

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG updated

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned

#### Pull Request Management:
- [ ] Linked to sub-task
- [ ] Linked to the epic
