### PR TITLE
Deprecated functions

### DIFF
--- a/src/sql/gazetteer_export_func.sql
+++ b/src/sql/gazetteer_export_func.sql
@@ -372,7 +372,7 @@ BEGIN
         NEX.desc_code,
         NEX.rev_gaz_ref,
         NEX.rev_treaty_legislation,
-        ST_Transform(ST_Force_2D(ST_Union(array_agg(ST_Buffer(POLY.shape,0)))), 4326) AS shape
+        ST_Transform(ST_Force2D(ST_Union(array_agg(ST_Buffer(POLY.shape,0)))), 4326) AS shape
     FROM gazetteer.name_export NEX
     JOIN gazetteer.feature_polygon POLY ON NEX.feat_id = POLY.feat_id
     GROUP BY

--- a/src/sql/gazetteer_reload_web.sql
+++ b/src/sql/gazetteer_reload_web.sql
@@ -1018,7 +1018,7 @@ insert into tmp_all_shapes1 (feat_id, geom_type, geom )
 select
 	g.feat_id,
 	g.geom_type,
-	st_union(ST_Force_2D(g.shape))
+	st_union(ST_Force2D(g.shape))
 from
    feature_geometry g
    join feature f on g.feat_id = f.feat_id

--- a/src/sql/test/schema/function_gazetteer.gaz_update_export_database.sql
+++ b/src/sql/test/schema/function_gazetteer.gaz_update_export_database.sql
@@ -1,0 +1,11 @@
+SET client_encoding = 'UTF-8';
+BEGIN;
+SELECT plan(1);
+
+SELECT ok(
+     gazetteer.gaz_update_export_database(),
+    'Invoke gaz_update_export_database function'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/src/sql/test/schema/function_gazetteer.gaz_update_export_database.sql
+++ b/src/sql/test/schema/function_gazetteer.gaz_update_export_database.sql
@@ -3,7 +3,7 @@ BEGIN;
 SELECT plan(1);
 
 SELECT is(
-     gazetteer.gaz_update_export_database(), 
+     gazetteer.gaz_update_export_database(),
      1,
     'Invoke gaz_update_export_database function'
 );

--- a/src/sql/test/schema/function_gazetteer.gaz_update_export_database.sql
+++ b/src/sql/test/schema/function_gazetteer.gaz_update_export_database.sql
@@ -2,8 +2,9 @@ SET client_encoding = 'UTF-8';
 BEGIN;
 SELECT plan(1);
 
-SELECT ok(
-     gazetteer.gaz_update_export_database(),
+SELECT is(
+     gazetteer.gaz_update_export_database(), 
+     1,
     'Invoke gaz_update_export_database function'
 );
 

--- a/src/sql/test/schema/schema.sql
+++ b/src/sql/test/schema/schema.sql
@@ -334,7 +334,7 @@ SELECT is(md5(p.prosrc), '3f9e2fb64cea9c0f32f03b49d948b491', 'Function gweb_simp
    AND proname = 'gweb_simplify_shapes'
    AND proargtypes::text = '23 23';
 
-SELECT is(md5(p.prosrc), '6e6dc290ab64c0770b48db2235aad65e', 'Function gweb_update_gaz_all_shapes body should match checksum')
+SELECT is(md5(p.prosrc), '69bf600d504c9266edfba5bb892dfe36', 'Function gweb_update_gaz_all_shapes body should match checksum')
   FROM pg_catalog.pg_proc p
   JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
  WHERE n.nspname = 'gazetteer'
@@ -516,10 +516,10 @@ SELECT is(md5(p.prosrc), '93d9bd6fe49b3a0f9286bd07eb9a5bc5', 'Function trgfunc_s
    AND proname = 'trgfunc_system_code_update'
    AND proargtypes::text = '';
 
-SELECT is(md5(p.prosrc), 'e36bd76b21fda2912e2477b5b0e4f4e6', 'Function gaz_update_export_database body should match checksum')
+SELECT is(md5(p.prosrc), 'c6e5c854ac2ddd9ff04d6e37351c1e25', 'Function gaz_update_export_database body should match checksum')
   FROM pg_catalog.pg_proc p
   JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
- WHERE n.nspname = 'gazetteer_export'
+ WHERE n.nspname = 'gazetteer'
    AND proname = 'gaz_update_export_database'
    AND proargtypes::text = '';
 

--- a/src/sql/test/schema/schema.sql
+++ b/src/sql/test/schema/schema.sql
@@ -1,6 +1,6 @@
 SET client_encoding = 'UTF-8';
 BEGIN;
-SELECT plan(129);
+SELECT plan(130);
 
 SELECT schemas_are(ARRAY[
     'gazetteer',


### PR DESCRIPTION
Fixes: #248
_Add new line for each issue that was fixed_



### Change Description:
Fixes deprecated function names since  PostGIS 2.1, i.e. ST_Force_2D is now called ST_Force2D
...

### Notes for Testing:
1. Start docker shell (db image) from Master
2. `su postgres`
3. Test that the function fails `psql -d gazetteer -c "BEGIN; SELECT gazetteer.gaz_update_export_database(); ROLLBACK;" `
4. Clone the repo `git clone https://github.com/linz/gazetteer.git`
5. Checkout the PR: `gh pr checkout 252`
6. Apply patch: `psql -d gazetteer -f gazetteer/src/sql/gazetteer_export_func.sql`
7. Test again: `psql -d gazetteer -c "BEGIN; SELECT gazetteer.gaz_update_export_database(); ROLLBACK;" `

...

#### Source Code Documentation Tasks:
- [x] README updated (where applicable)
- [x] CHANGELOG updated

#### User Documentation Tasks:
- [x] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [x] Added tests that fail without this change
- [x] All tests are passing in development environment
- [x] Reviewers assigned

#### Pull Request Management:
- [x] Linked to sub-task
- [x] Linked to the epic
