### PR TITLE
ci: remove unknown linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
   deploy:
     name: deploy
     if: startswith(github.ref, 'refs/tags/v')
-    needs: [linter, test_schema, test_docker]
+    needs: [test_schema, test_docker]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code


### PR DESCRIPTION
linter step was removed in https://github.com/linz/gazetteer/pull/279/files therefore the dependency needs to be removed here too.